### PR TITLE
Separate typechecking from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
   include:
     - stage: test
       script: 
+      - npm run typecheck
       - npm run lint
       - npm run test
       - npm run codecov

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "codecov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "docs": "typedoc",
     "lint": "eslint --ext=ts,tsx,js ./src",
-    "test": "nyc mocha",
-    "test:watch": "mocha --watch",
+    "test": "TS_NODE_TRANSPILE_ONLY=true nyc mocha",
+    "test:watch": "TS_NODE_TRANSPILE_ONLY=true mocha --watch",
+    "typecheck": "tsc --noEmit",
     "start": "nodemon"
   },
   "devDependencies": {


### PR DESCRIPTION
Type errors emitted by ts-node will prevent tests from running but won't be reported to the user. These errors can be ingored with the TS_NODE_TRANSPILE_ONLY flag, but those are still things that we want to detect. So I've added a separate typecheck script, which will be run on travis before any linting or testing is done.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
N/A

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
