### PR TITLE
Switch TypeDoc to file mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,19 @@ stages:
   - name: documentation
     if: branch = master
   - name: build
-    if: (branch = master OR branch = develop) AND type != pull_request 
+    if: (branch = master OR branch = develop) AND type != pull_request
 jobs:
   include:
     - stage: test
-      script: 
+      script:
       - npm run typecheck
       - npm run lint
       - npm run test
       - npm run codecov
     - stage: documentation
-      script: npm run docs
+      script:
+        - npm run docs
+        - touch ./docs/.nojekyll
       deploy:
         provider: pages
         skip_cleanup: true

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "mode": "modules",
+  "mode": "file",
   "out": "docs",
   "exclude": "**/__tests__/*",
   "excludeExternals": true,


### PR DESCRIPTION
Submodules are currently broken in TypeDoc (as-of TypeDoc v`0.14`). This appears to be because of a change made by TypeDoc to their underlying API. More information in: christopherthielen/typedoc-plugin-external-module-name#332. That being the case, using file mode at least cleans up the output a little and makes it easier to until submodules can be used.

This PR aims to clean up the organization of documented objects a little so that this:

![image](https://user-images.githubusercontent.com/50675045/60448285-5233de80-9bf3-11e9-90ae-a93cd9a6917b.png)

Ends up looking like this:

![image](https://user-images.githubusercontent.com/50675045/60448341-65df4500-9bf3-11e9-82ad-39258421bad1.png)


## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Provides a (partial) work-around for #17

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
